### PR TITLE
set TS compile options: target to es5

### DIFF
--- a/.changeset/silent-olives-pump.md
+++ b/.changeset/silent-olives-pump.md
@@ -1,0 +1,23 @@
+---
+'create-farrow-app': patch
+'farrow': patch
+'farrow-api': patch
+'farrow-api-client': patch
+'farrow-api-server': patch
+'farrow-cors': patch
+'farrow-deno-api': patch
+'farrow-express': patch
+'farrow-federation': patch
+'farrow-http': patch
+'farrow-json-schema': patch
+'farrow-koa': patch
+'farrow-module': patch
+'farrow-next': patch
+'farrow-next-server': patch
+'farrow-pipeline': patch
+'farrow-react': patch
+'farrow-schema': patch
+'farrow-vite': patch
+---
+
+set compile option: `target` to es5

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "suppressImplicitAnyIndexErrors": true,
     "suppressExcessPropertyErrors": true,
     "forceConsistentCasingInFileNames": true,
-    "target": "ES6",
+    "target": "ES5",
     "sourceMap": true,
     "esModuleInterop": true,
     "stripInternal": true,


### PR DESCRIPTION
It should be noted that it will publish all package. #157 

```md
'farrow': patch
'farrow-api': patch
'farrow-api-client': patch
'farrow-api-server': patch
'farrow-cors': patch
'farrow-deno-api': patch
'farrow-express': patch
'farrow-federation': patch
'farrow-http': patch
'farrow-json-schema': patch
'farrow-koa': patch
'farrow-module': patch
'farrow-next': patch
'farrow-next-server': patch
'farrow-pipeline': patch
'farrow-react': patch
'farrow-schema': patch
'farrow-vite': patch
```