### PR TITLE
feat: Disable Redux DevTools in production

### DIFF
--- a/packages/farrow-next/src/controller.tsx
+++ b/packages/farrow-next/src/controller.tsx
@@ -226,7 +226,7 @@ export abstract class Controller extends Module {
   /**
    * enable redux-devtools
    */
-  devtools: boolean | string = true
+  devtools: boolean | string = process.env.NODE_ENV !== 'production'
 
   /**
    * enable redux-logger


### PR DESCRIPTION
Disable Redux DevTools by default in production